### PR TITLE
Update bitrise.yml

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -4,21 +4,17 @@ project_type: other
 workflows:
   update-algolia:
     envs:
-      - SPEC_JSON_PATH: '$SPEC_JSON_PATH'
-      - ALGOLIA_APP_ID: '$ALGOLIA_APP_ID'
-      - ALGOLIA_API_KEY: '$ALGOLIA_API_KEY'
-      - DRY_RUN: '$DRY_RUN'
+    - SPEC_JSON_PATH: '$SPEC_JSON_PATH'
+    - ALGOLIA_APP_ID: '$ALGOLIA_APP_ID'
+    - ALGOLIA_API_KEY: '$ALGOLIA_API_KEY'
+    - DRY_RUN: '$DRY_RUN'
     steps:
-      - script@1.1.6:
-          title: Update algolia steps based on spec.json
-          inputs:
-            - content: |-
-                #!/usr/bin/env bash
-                set -ex
-
-                cd scripts
-                corepack enable
-                yarn install --prod
-                cd ..
-
-                yarn update-algolia "$SPEC_JSON_PATH"
+    - yarn@0:
+        inputs:
+        - workdir: ./scripts
+        - command: install
+        - args: --prod
+    - yarn@0:
+        inputs:
+        - command: update-algolia
+        - args: $SPEC_JSON_PATH


### PR DESCRIPTION
The update-algolia workflow started failing here: https://app.bitrise.io/build/75f18ea7-2fdd-49eb-b8ad-67ca89a8fa41
with the error message:
```
+ yarn install --prod
No preset version installed for command yarn
Please install a version by running one of the following:
asdf install nodejs 18.16.0
or add one of the following versions in your config file at /bitrise/src/.tool-versions
nodejs 16
nodejs 16.20
nodejs 16.20.2
exit status 126
```

[This problem has been solved In the yarn step](https://github.com/bitrise-steplib/steps-yarn/pull/28), so this PR migrates the custom script used in the workflow to yarn steps.