### PR TITLE
fix: is_latest & latest_version_number fields are not updating in Algolia

### DIFF
--- a/scripts/update-algolia.js
+++ b/scripts/update-algolia.js
@@ -41,7 +41,7 @@ async function perform() {
         ]);
       }
     } else {
-      const compareChangedStepsBy = ['info', 'step.asset_urls'];
+      const compareChangedStepsBy = ['info', 'is_latest', 'step.asset_urls'];
 
       console.log('Updating steps and inputs..');
       const [currentSteps, currentInputs] = await Promise.all([

--- a/scripts/update-algolia.js
+++ b/scripts/update-algolia.js
@@ -41,7 +41,7 @@ async function perform() {
         ]);
       }
     } else {
-      const compareChangedStepsBy = ['info', 'is_latest', 'step.asset_urls'];
+      const compareChangedStepsBy = ['info', 'is_latest', 'latest_version_number', 'step.asset_urls'];
 
       console.log('Updating steps and inputs..');
       const [currentSteps, currentInputs] = await Promise.all([


### PR DESCRIPTION
JIRA ticket: [CI-3245](https://bitrise.atlassian.net/browse/CI-3245)

[CI-3245]: https://bitrise.atlassian.net/browse/CI-3245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Before this fix, the `stepsToUpdate` [constant](https://github.com/bitrise-io/steplib-search/blob/master/scripts/update-algolia.js#L66) contains only the newest version of the updated Step, but we need to update the `is_latest` (set it to `false`) and the `latest_version_number` fields of the previous versions of the new Step as well. 