### PR TITLE
Fix update script error

### DIFF
--- a/scripts/update-algolia.js
+++ b/scripts/update-algolia.js
@@ -107,7 +107,7 @@ async function browseAll(idx, attributesToRetrieve = ['cvs']) {
     attributesToRetrieve,
     attributesToHighlight: [],
     typoTolerance: false,
-    restrictSearchableAttributes: ['cvs'],
+    restrictSearchableAttributes: ['cvs', 'id'],
     batch: (hits) => (result = result.concat(hits)),
   });
 


### PR DESCRIPTION
```
  name: 'ApiError',
  message: 'invalid setting for restrictSearchableAttributes, you should request all attributes with same priority: cvs, id,  does not exist',
```

I can't explain what changed recently that caused this eror, but here we are. I see no recent code change that changed the index structure or priorities, but adding the `id` attribute seems to work.

Ref: https://www.algolia.com/doc/api-reference/api-parameters/restrictSearchableAttributes/?client=javascript#examples

I tested it locally:

```
❯ node scripts/update-algolia.js /tmp/spec.json
Parsed..
3102 step versions
26465 step version inputs

Updating steps and inputs..
Added..
0 new step versions
0 new step version inputs
Updated..
0 step version

Wait for Algolia to sync
Checking indices
Done..
```

I guess the real test will be after the next step release and steplib change.